### PR TITLE
adding "Cardboard" functionality, Mobile Fullscreen and (OpenTok) webRTC <video> element overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ THETA_GL is under the MIT license
 
 
 [Original Japanese README starts here]
----
+----
 
 # THETA_GL
 THETA WebGL Viewer with three.js

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ THETA_GL is under the MIT license
 
 
 [Original Japanese README starts here]
-
+---
 
 # THETA_GL
 THETA WebGL Viewer with three.js

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 THETA WebGL Viewer using three.js (Javascript 3D library)
 
 
-[Many thanks to [mganeko](https://github.com/mganeko) for this useful repo! English translation of README.md file for @mganeko’s THETA_GL repo provided by the RICOH THETA Unofficial Guide. Original Japanese language README.md file information is appended below. This is provided “as-is” and unofficial. Comments and edits welcome. More information on useful GitHub repos for the RICOH THETA curatated by the RICOH THETA Unofficial Guide [here](http://lists.theta360.guide/t/theta-github-repository/199/1)]
+[Many thanks to [mganeko](https://github.com/mganeko) for this useful repo! This English translation of the README.md file for mganeko’s THETA_GL repo provided by the RICOH THETA Unofficial Guide. Original Japanese language README.md file information is appended below. This is provided “as-is and unofficial." Comments and edits welcome. More information on useful GitHub repos for the RICOH THETA curatated by the RICOH THETA Unofficial Guide [here](http://lists.theta360.guide/t/theta-github-repository/199/1)]
 
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ THETA_GL.startAnimate();
 ## ライセンス
 THETA_GLはMITランセンスで提供されます
 
+![Analytics](https://ga-beacon.appspot.com/UA-73311422-5/Theta-WebGL-viewer)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ THETA WebGL Viewer using three.js (Javascript 3D library)
   * Hekomi’s “Using RICOH THETA Live View With Unity” http://lists.theta360.guide/t/using-ricoh-theta-live-view-with-unity/70/1
   * Based on the UV Mapping information above, a mapping JSON converted and fine tuned for three.js by a Mr. Baba
 
-* Using anzu-sdk.js (https://github.com/shiguredo/anzu-js-sdk) from the WebRTC SFU as a Service called Anzu, a WebRTC distribution service
+* Using [anzu-sdk.js](https://github.com/shiguredo/anzu-js-sdk) from the WebRTC SFU as a Service called Anzu, a WebRTC distribution service
   * The Anzu WebRTC SFU as a Service is provided by the company Shiguredo, K.K. (Japan)
   * anzu-sdk.js is under the Apache License Version 2.0
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ I have tested and confirmed the following operating environment:
 * Chrome for Android
 * Firefox for Android
 
-※Maybe because Firefox for Android uses m4v format, playback for recorded video files is not possible.
+_Maybe because Firefox for Android uses m4v format, playback for recorded video files is not possible._
 
 ## Samples
 

--- a/README.md
+++ b/README.md
@@ -37,12 +37,10 @@ _Maybe because Firefox for Android uses m4v format, playback for recorded video 
 ## Samples
 
 ### Playback of prerecorded video file
-* Displaying a video sample taken with THETA S
-* https://mganeko.github.io/THETA_GL/movie_360.html
+* [Displaying a video sample](https://mganeko.github.io/THETA_GL/movie_360.html) taken with THETA S
 
 ### Connecting to USB Camera
-* Sample using `navigator.getUserMedia()` with camera video sample
-* [https://mganeko.github.io/THETA_GL/movie_360.html](https://mganeko.github.io/THETA_GL/movie_360.html)
+* [Sample using `navigator.getUserMedia()`](https://mganeko.github.io/THETA_GL/movie_360.html) with camera video sample 
 
 ### Using WebRTC SFU Distribution Video
 [Translator’s Note: This section of links appears to need an account with this service, and this section of links do not appear to work.]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ _Maybe because Firefox for Android uses m4v format, playback for recorded video 
 * https://mganeko.github.io/THETA_GL/movie_360.html
 
 ### Connecting to USB Camera
-* Sample using navigator.getUserMedia() with camera video sample
+* Sample using `navigator.getUserMedia()` with camera video sample
 * [https://mganeko.github.io/THETA_GL/movie_360.html](https://mganeko.github.io/THETA_GL/movie_360.html)
 
 ### Using WebRTC SFU Distribution Video

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 THETA WebGL Viewer using three.js (Javascript 3D library)
 
 
-[Many thanks to https://github.com/mganeko for this useful repo. English translation of README.md file for @mganeko’s THETA_GL repo provided by the RICOH THETA Unofficial Guide. Original Japanese language README.md file information is appended below. This is provided “as-is” and unofficial. Comments and edits welcome. More information on useful GitHub repos for the RICOH THETA curatated by the RICOH THETA Unofficial Guide [here](http://lists.theta360.guide/t/theta-github-repository/199/1)]
+[Many thanks to [mganeko](https://github.com/mganeko) for this useful repo! English translation of README.md file for @mganeko’s THETA_GL repo provided by the RICOH THETA Unofficial Guide. Original Japanese language README.md file information is appended below. This is provided “as-is” and unofficial. Comments and edits welcome. More information on useful GitHub repos for the RICOH THETA curatated by the RICOH THETA Unofficial Guide [here](http://lists.theta360.guide/t/theta-github-repository/199/1)]
 
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -1,4 +1,109 @@
 # THETA_GL
+
+[Many thanks to https://github.com/mganeko for this useful repo. English translation of README.md file for @mganeko’s THETA_GL repo provided by the RICOH THETA Unofficial Guide. Original Japanese language README.md file information is appended below. This is provided “as-is” and unofficial. Comments and edits welcome. More information on the RICOH THETA Unofficial Guide here: http://lists.theta360.guide/t/theta-github-repository/199/1]
+
+THETA WebGL Viewer using three.js (Javascript 3D library)
+
+
+## Acknowledgments
+
+* In order to render WebGL, three.js is used
+  * To show rendering of full photospheres, samples of panoramas / equirectangular are referenced
+  * three.js is covered under the MIT license
+
+* In order to handle UV Mapping, the following data was utilized:
+  * Hekomi’s “Using RICOH THETA Live View With Unity” http://lists.theta360.guide/t/using-ricoh-theta-live-view-with-unity/70/1
+  * Based on the UV Mapping information above, a mapping JSON converted and fine tuned for three.js by a Mr. Baba
+
+* Using anzu-sdk.js (https://github.com/shiguredo/anzu-js-sdk) from the WebRTC SFU as a Service called Anzu, a WebRTC distribution service
+  * The Anzu WebRTC SFU as a Service is provided by the company Shiguredo, K.K. (Japan)
+  * anzu-sdk.js is under the Apache License Version 2.0
+
+Thank you, everyone.
+
+## Operating Environment
+
+I have tested and confirmed the following operating environment:
+
+* Chrome 47.0.2526.106 (64-bit) for MacOS X
+* Firefox 43.0.3 for MacOS X
+* Chrome 47.0.2526.106 m for Windows
+* Firefox 43.0.2 for Windows
+* Chrome for Android
+* Firefox for Android
+
+※Maybe because Firefox for Android uses m4v format, playback for recorded video files is not possible.
+
+## Samples
+
+### Playback of prerecorded video file
+* Displaying a video sample taken with THETA S
+* https://mganeko.github.io/THETA_GL/movie_360.html
+
+### Connecting to USB Camera
+* Sample using navigator.getUserMedia() with camera video sample
+* [https://mganeko.github.io/THETA_GL/movie_360.html](https://mganeko.github.io/THETA_GL/movie_360.html)
+
+### Using WebRTC SFU Distribution Video
+[Translator’s Note: This section of links appears to need an account with this service, and this section of links do not appear to work.]
+* Sample of [Anzu WebRTC SFU as a Service](https://anzu.shiguredo.jp/) video distribution service 
+* [Example of distribution](https://mganeko.github.io/THETA_GL/theta_anzu_up.html)
+* [Example of viewing](https://mganeko.github.io/THETA_GL/theta_anzu_360.html)
+* ~~After starting distribution from the Anzu Dashboard, set the Channel ID and connect~~ [crossed out in original Japanese README]
+* Confirm the Channel ID and distribution token in the [Anzu Dashboard](https://mganeko.github.io/THETA_GL/theta_anzu_up.html), then input them on the page and start broadcasting. For viewing, set the Channel ID on [theta_anzu_360.html](https://mganeko.github.io/THETA_GL/theta_anzu_360.html) page and connect.
+
+## Usage
+
+#### Prep
+
+* Load three.js and three.min.js in HTML
+  * Download the newest version [here](http://github.com/mrdoob/three.js/zipball/master) or use the [CDN version](https://cdnjs.com/libraries/three.js/)
+* Load theta_gl.js in HTML
+  * You must have the JSON file in the UV folder when you use it
+* When you use Anzu, anzu.js or anzu.min.js is required
+  * Get the [newest version from Github](https://github.com/shiguredo/anzu-js-sdk)
+
+
+## Initialization
+
+* THETA_GL.init(divId, autoResuze, debugFlag)
+  * string divId: It will be a Canvas container displaying WebGL, set the div element ID [REQUIRED]
+  * bool autoResize: Comply with window resize or not (true/false) - default is true
+  * bool debugFlag: For debugging, running video elements or displaying canvas elements, or displaying log information in the console - default is false
+
+#### Starting WebGL Animation
+
+* THETA_GL.startAnimate()
+
+#### Setting the source URL of videos
+* THETA_GL.setVideoSrc(url, loopFlag)
+  * string url: URL for videos. Use a web URL or set a URL created with URL.createObjectURL() [REQUIRED]
+  * bool loopFlag: Run the video in a loop or not (true/false) - default is false
+
+#### Stopping Video
+* THETA_GL.stopVideoSrc()
+
+#### Setting Device Orientation
+* THETA_GL.followOrientation(flag)
+  * bool flag: Setting whether to follow the smart device orientation or not. [REQUIRED]
+
+### Code Samples
+```
+var url = 'http://yourserver.com/video.mp4';
+THETA_GL.init('container', true, false);
+THETA_GL.setVideoSrc(url, true);
+THETA_GL.startAnimate();
+```
+
+33 License
+
+THETA_GL is under the MIT license
+
+
+[Original Japanese README starts here]
+
+
+# THETA_GL
 THETA WebGL Viewer with three.js
 
 RICHO THETA S の映像をWebGL(three.js)とUVマッピングを用いて、全天球動画としてブラウザで表示します。

--- a/README.md
+++ b/README.md
@@ -66,26 +66,26 @@ _Maybe because Firefox for Android uses m4v format, playback for recorded video 
 
 ## Initialization
 
-* THETA_GL.init(divId, autoResuze, debugFlag)
-  * string divId: It will be a Canvas container displaying WebGL, set the div element ID [REQUIRED]
-  * bool autoResize: Comply with window resize or not (true/false) - default is true
-  * bool debugFlag: For debugging, running video elements or displaying canvas elements, or displaying log information in the console - default is false
+* `THETA_GL.init(divId, autoResuze, debugFlag)`
+  * `string divId`: It will be a Canvas container displaying WebGL, set the div element ID [REQUIRED]
+  * `bool autoResize`: Comply with window resize or not (true/false) - default is true
+  * `bool debugFlag`: For debugging, running video elements or displaying canvas elements, or displaying log information in the console - default is false
 
 #### Starting WebGL Animation
 
-* THETA_GL.startAnimate()
+* `THETA_GL.startAnimate()`
 
 #### Setting the source URL of videos
-* THETA_GL.setVideoSrc(url, loopFlag)
-  * string url: URL for videos. Use a web URL or set a URL created with URL.createObjectURL() [REQUIRED]
-  * bool loopFlag: Run the video in a loop or not (true/false) - default is false
+* `THETA_GL.setVideoSrc(url, loopFlag)`
+  * `string url`: URL for videos. Use a web URL or set a URL created with `URL.createObjectURL()` [REQUIRED]
+  * `bool loopFlag`: Run the video in a loop or not (true/false) - default is false
 
 #### Stopping Video
-* THETA_GL.stopVideoSrc()
+* `THETA_GL.stopVideoSrc()`
 
 #### Setting Device Orientation
-* THETA_GL.followOrientation(flag)
-  * bool flag: Setting whether to follow the smart device orientation or not. [REQUIRED]
+* `THETA_GL.followOrientation(flag)`
+  * `bool flag`: Setting whether to follow the smart device orientation or not. [REQUIRED]
 
 ### Code Samples
 ```
@@ -95,7 +95,7 @@ THETA_GL.setVideoSrc(url, true);
 THETA_GL.startAnimate();
 ```
 
-33 License
+## License
 
 THETA_GL is under the MIT license
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ THETA WebGL Viewer using three.js (Javascript 3D library)
   * three.js is covered under the MIT license
 
 * In order to handle UV Mapping, the following data was utilized:
-  * Hekomi’s “Using RICOH THETA Live View With Unity” http://lists.theta360.guide/t/using-ricoh-theta-live-view-with-unity/70/1
+  * Hekomi’s [“Using RICOH THETA Live View With Unity”](http://lists.theta360.guide/t/using-ricoh-theta-live-view-with-unity/70/1)
   * Based on the UV Mapping information above, a mapping JSON converted and fine tuned for three.js by a Mr. Baba
 
 * Using [anzu-sdk.js](https://github.com/shiguredo/anzu-js-sdk) from the WebRTC SFU as a Service called Anzu, a WebRTC distribution service

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 THETA WebGL Viewer using three.js (Javascript 3D library)
 
 
-[Many thanks to https://github.com/mganeko for this useful repo. English translation of README.md file for @mganeko’s THETA_GL repo provided by the RICOH THETA Unofficial Guide. Original Japanese language README.md file information is appended below. This is provided “as-is” and unofficial. Comments and edits welcome. More information on the RICOH THETA Unofficial Guide here: http://lists.theta360.guide/t/theta-github-repository/199/1]
+[Many thanks to https://github.com/mganeko for this useful repo. English translation of README.md file for @mganeko’s THETA_GL repo provided by the RICOH THETA Unofficial Guide. Original Japanese language README.md file information is appended below. This is provided “as-is” and unofficial. Comments and edits welcome. More information on useful GitHub repos for the RICOH THETA curatated by the RICOH THETA Unofficial Guide [here](http://lists.theta360.guide/t/theta-github-repository/199/1)]
 
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # THETA_GL
+THETA WebGL Viewer using three.js (Javascript 3D library)
+
 
 [Many thanks to https://github.com/mganeko for this useful repo. English translation of README.md file for @mganeko’s THETA_GL repo provided by the RICOH THETA Unofficial Guide. Original Japanese language README.md file information is appended below. This is provided “as-is” and unofficial. Comments and edits welcome. More information on the RICOH THETA Unofficial Guide here: http://lists.theta360.guide/t/theta-github-repository/199/1]
-
-THETA WebGL Viewer using three.js (Javascript 3D library)
 
 
 ## Acknowledgments


### PR DESCRIPTION
Wanted to make a PR from what I've built to enable discuss.io to use the THETA 360 camera with OpenTok's webRTC streaming service.

This PR adds new functions to call from the client side. Here are some examples:
```
var publisher360 = new _theta_gl();; // global pub/sub theta_gl instance

// to enable a 360 "preview" with OpenTok's publisher
var publisher = $('.OT_publisher').find('video')[0];
publisher360.init(/* divId */ 'self360', /* autoResize */ true,  /* debug */ false);
publisher360.overrideVideoElement(publisher);
publisher360.startAnimate();

// to disable a 360 "preview" over the OT stream
publisher360.stopAnimate();
$('#self360').find('canvas').remove();
```

There can be separate subscribers within a session. So you'll need a different theta_gl instance for each one
```
var subStream = $( '#' + opentokID );
var subVideo; // defined on start360

if (subStream.theta_gl) {
  throw "subStream.theta_gl already exists. Cannot enable360subscriber more than once";
}
subStream.theta_gl = new _theta_gl();

// starting 360 on the subscriber element
if (!subVideo) {
    subVideo = subStream.find('video')[0];
}
subStream.theta_gl.init(/* divId */ 'sub360', /* autoResize */ true,  /* debug */ false);
subStream.theta_gl.overrideVideoElement(subVideo);
subStream.theta_gl.startAnimate();

// stopping 360 on the subscriber element
subStream.theta_gl.stopAnimate();
subStream.find('canvas').remove();
```

You can detect if it's a mobile to device to enable/disable fullscreen
```
var mobile = /Mobi/.test(navigator.userAgent); // check to see if it's a mobile device

if (mobile) {
    var fullscreenCanvas = subStream.find('canvas')[0];
    subStream.theta_gl.disableStereoEffect();
    subStream.theta_gl.enableFullScreen(fullscreenCanvas, true);
}
```

Finally, you can use a UI element (with a high z-index) to toggle different modes. Here's some example code that I use as an onclick function for these elements:
```
// the following code uses predefined start/stop 360Subscriber methods as exemplified in the previous code samples
    // add enable/disable functions to toggle elements
    function three60click(element, stereoView) {
      // change toggle, if canvas not present
      if (!subStream.find('canvas')[0]) {
        element.data('toggle', 'disabled');
      }

      // start/stop 360 subscriber tools
      switch (element.data('toggle')) {
        case "disabled":
          start360Subscriber();
          if (mobile) {
            subscribeElement.hide();
            cardboardMode.show();
            cardboardMode.data('toggle', 'enabled');
          }
          element.data('toggle', 'enabled');
          break;
        case "enabled":
          if (mobile) {
            if (stereoView) {
              subStream.theta_gl.enableStereoEffect();
              subStream.theta_gl.startAnimate();
              subscribeElement.show();
            } else {
              subStream.theta_gl.disableStereoEffect();
              // subStream.theta_gl.stopAnimate(); // need to fix half-screen
              subStream.theta_gl.startAnimate();
              subscribeElement.hide();
              cardboardMode.show();
            }
          } else {
            stop360Subscriber();
            element.data('toggle', 'disabled');
          }
          break;
        default:
          console.log('error');
        }
    }
```